### PR TITLE
fix: discord link on homepage

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -32,7 +32,7 @@ The Radiant Segments API is designed to enable builders to easily query, observe
   <Card
     title="Join Our Discord Community"
     icon="discord"
-    href="https://loopholelabs.io/discord"
+    href="https://discord.com/invite/AXZTaepWGb"
   >
     Our Discord server is a great place to get help
     with all things Radiant and Segment API.


### PR DESCRIPTION
update discord link from https://loopholelabs.io/discord to https://discord.com/invite/AXZTaepWGb